### PR TITLE
Allows read only NOTEBOOKS_DIR

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -47,7 +47,7 @@ if(!nbDir) {
     try {
         fs.mkdirSync(nbDir);
     } catch(e) {
-        if(e.code !== 'EEXIST') {
+        if(e.code !== 'EEXIST' && e.code !== 'EROFS') {
             throw e;
         }
     }


### PR DESCRIPTION
If the NOTEBOOKS_DIR is on a read only filesystem, the dashboard
server gives the following error:

/usr/local/lib/node_modules/jupyter-dashboards-server/app/config.js:51
            throw e;
                  ^
Error: EROFS, read-only file system '/var/www/html/readonly/dashboards-public'
    at Object.fs.mkdirSync (fs.js:651:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/jupyter-dashboards-server                                                   /app/config.js:48:12)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/jupyter-dashboards-server                                                   /app/handlebars-helpers.js:6:14)
    at Module._compile (module.js:456:26)

This patch fixes this bug.
